### PR TITLE
Track future development through GitHub Issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# sub2sub development
+
+## Agent skills
+
+### Issue tracker
+
+Before planning, creating, implementing or updating work, read [the GitHub issue workflow](docs/agents/issue-tracker.md). Future requirements, specifications and work status live in `mekoand/sub2sub` Issues.
+
+### Triage labels
+
+When triaging issues or selecting work, use [the five triage roles](docs/agents/triage-labels.md). Readiness and completion are separate.
+
+### Domain docs
+
+Before exploring or changing code, follow [the domain reading rules](docs/agents/domain.md).
+
+## Product boundary
+
+Before changing delegation, read [the architecture](docs/architecture.md). The provider checks the quality of its work; the caller checks delivery completeness. Plugin regression tests are separate from those task checks.
+
+For implementation, testing and review, follow [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@
 
 ## Before changing code
 
+- Track new requirements and work in [GitHub Issues](https://github.com/mekoand/sub2sub/issues), following the [issue workflow](https://github.com/mekoand/sub2sub/blob/main/docs/agents/issue-tracker.md). Keep small changes in one issue and link implementation PRs to it.
 - Describe the concrete problem and expected behavior. Discuss changes to pairing, permissions, cleanup, or persisted data before a broad implementation.
 - Read [the architecture](docs/architecture.md) and [usage and execution limits](docs/usage.en.md#delegate-and-follow-up).
 - Never include invitations, credentials, real task state, personal paths, or private project content in a contribution. Use synthetic fixtures.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,7 @@
+# Domain docs
+
+Before exploring or changing code, read the root [CONTEXT.md](../../CONTEXT.md) glossary. For changes to delegation or execution, also read [the architecture](../architecture.md). Read relevant documents under `docs/adr/` when that directory exists.
+
+Keep `CONTEXT.md` focused on domain terms. Feature specifications and agreed decisions belong in their GitHub issues; use an ADR when a lasting architectural decision warrants one. Follow [the issue workflow](issue-tracker.md) for task state.
+
+Use the same terms in discussions, issues and code. Surface conflicts with an accepted decision before changing it. Create documents when there is a decision to record, rather than creating empty directories for the process.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,33 @@
+# Issue tracker: GitHub
+
+Future requirements, specifications and work status are tracked in [mekoand/sub2sub Issues](https://github.com/mekoand/sub2sub/issues), starting after 0.5.3. Completed local Markdown tasks remain historical records. `.scratch/` may hold working notes, but current scope, decisions and status belong in the issue.
+
+## Plan the work
+
+- Search existing issues before creating one. A small change needs one issue; a larger effort may have a parent specification and independently verifiable child tasks.
+- Each implementation issue states the problem, expected result, scope and non-goals, acceptance criteria, and blocking issues. Write from the user's perspective; each task should deliver a complete, testable behavior.
+- Discuss unresolved product choices before marking work ready. Matt's `grill-with-docs` → `to-spec` → `to-tickets` flow fits larger work; an already clear small change can go directly to one issue. Contributors can follow this workflow without installing the skills.
+- Use `triage` for incoming reports. Maintainer-approved specifications and tasks can use `ready-for-agent` directly. See [triage labels](triage-labels.md).
+
+## Implement and finish
+
+1. Read the issue, comments and linked decisions. Work within the maintainer's request: a planning or ticketing request ends after the issue updates.
+2. Start an implementation task once its prerequisites are satisfied. `ready-for-agent` means the brief is clear; check blockers separately. Use native issue dependencies where available, otherwise list them under `Blocked by`. A prerequisite is satisfied by its required outcome, not merely by being closed as a duplicate or declined request.
+3. Assign the issue when starting, and work on a branch from the public repository's current `main`. For a parent with implementation children, work the children and use the parent to track the combined result.
+4. Open a PR linked to the issue. Record the checks actually run and any remaining limitations. Follow [the contribution guide](../../CONTRIBUTING.md) for testing and review.
+5. Use `Closes #N` when the PR meets the issue's full acceptance criteria; merge then closes it. A partial PR uses `Refs #N` and leaves the issue open. Close a parent only after its overall acceptance criteria are met. Research-only issues close after the agreed findings are recorded; no code PR is required.
+
+Issue open/closed state, assignees and linked PRs track progress. The triage labels describe what kind of attention an issue needs; they are not a second progress board. Update the issue when scope or blockers change, and record the release version when relevant.
+
+## Tracker operations
+
+Use `gh` with the explicit repository, even when working in a local copy without the public remote:
+
+```sh
+gh issue list --repo mekoand/sub2sub --state open
+gh issue view 1 --repo mekoand/sub2sub --comments
+```
+
+Replace `1` with the relevant issue number. Read labels along with the body and comments. When a Matt skill says to publish a specification or ticket, create a GitHub issue; when it says to fetch a ticket, read that issue. For multiline issue, comment and PR bodies, use a file with actual newlines and `--body-file`.
+
+**PRs as a request surface: no.** Incoming reports are triaged as issues; implementation PRs stay linked to their issues.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage labels
+
+Use Matt's five canonical roles directly:
+
+| Label | Meaning |
+| --- | --- |
+| `needs-triage` | Maintainer needs to evaluate the issue. |
+| `needs-info` | Required information is missing. |
+| `ready-for-agent` | The brief is clear enough for an agent; prerequisites still need checking. |
+| `ready-for-human` | Human judgment, access or implementation is needed. |
+| `wontfix` | The request will not be pursued; record the reason and close it. |
+
+After triage, keep exactly one role label. Use `bug` or `enhancement` for the category; other existing labels may add context. Maintainer-approved tasks can enter as `ready-for-agent` without repeating triage.
+
+Use GitHub open/closed state and linked PRs for progress and completion, following [the issue workflow](issue-tracker.md). A closed issue may be completed or declined; retain that distinction when evaluating dependencies.


### PR DESCRIPTION
Future requirements and implementation status move from local Markdown tasks to GitHub Issues. This adds the public agent entry point and concise tracker, triage and domain instructions, with a link from the contribution guide. Completed local tasks remain historical records.

The four missing triage labels have been created, and the local workflow documents are synchronized. Readiness is separate from progress; implementation uses linked PRs, and closure follows acceptance and merge.

Validation: checked relative documentation links, matching local/public workflow documents, and the live issue and label configuration. This changes documentation only.

Closes #1
